### PR TITLE
Check response codes and add default values to `run`

### DIFF
--- a/bagitify/bagitify.py
+++ b/bagitify/bagitify.py
@@ -16,6 +16,7 @@ dt_format = "%Y-%m-%dT%H:%M:%SZ"
 def get_start_end(tabledap_url: str) -> (datetime, datetime):
     start_end_url = f'{tabledap_url}.csv0?time&orderByMinMax(%22time%22)'
     r = requests.get(start_end_url, allow_redirects=True)
+    r.raise_for_status()
     processed = [parse_datetime(dt_str) for dt_str in r.content.decode(
         "utf-8").strip().split("\n")]
     start = processed[0]
@@ -106,6 +107,7 @@ def get_dataset_name_from_tabledap_url(tabledap_url: str) -> str:
 def get_metadata(tabledap_url: str) -> dict:
     metadata_url = tabledap_url.replace("/tabledap/", "/info/") + "/index.json"
     r = requests.get(metadata_url, allow_redirects=True)
+    r.raise_for_status()
     metadata = json.loads(r.content.decode("utf-8"))
     return metadata
 

--- a/bagitify/bagitify.py
+++ b/bagitify/bagitify.py
@@ -177,7 +177,7 @@ def config_metadata_from_env() -> dict:
     return config_metadata
 
 
-def run(tabledap_url: str, bag_directory: Path, requested_start_datetime: datetime, requested_end_datetime: datetime):
+def run(tabledap_url: str, bag_directory: Path, requested_start_datetime: datetime = None, requested_end_datetime: datetime = None):
     # clean up tabledap url
     tabledap_url = tabledap_url.lower()
     # remove .html suffix if present


### PR DESCRIPTION
Raising the right type of exception
- use `raise_for_status()` on all responses before continuing
- before `get_start_end` would attempt to  parse the response body as a date even in case of an error 500
  - this would result in a `ValueError`

Defaults
- when used via CLI `None` is already the defalt and therefore can be passed to `run`
- the code already handles `None` as a possibility
- this way anyone importing `run` doesn't have to pass the `None` themselves explicitly