### PR TITLE
Make netCDF file download more atomic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ncei-archives
 *.pyc
 .envrc
 *.egg-info
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 FROM mambaorg/micromamba:1.5.1
-COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml
+COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/project/environment.yml
+COPY --chown=$MAMBA_USER:$MAMBA_USER pyproject.toml /tmp/project/pyproject.toml
+COPY --chown=$MAMBA_USER:$MAMBA_USER bagitify /tmp/project/bagitify
 
-RUN micromamba install -y -n base -f /tmp/environment.yml && \
+RUN micromamba install -y -n base -f /tmp/project/environment.yml && \
     micromamba clean --all --yes
 
 WORKDIR /srv/bagitify
 
-COPY ./bagitify.py .
-
 ENV PYTHONUNBUFFERED=1
+# so that `python -m` can find the module
+ENV PYTHONPATH=/tmp/project
 
-ENTRYPOINT ["/usr/local/bin/_entrypoint.sh", "./bagitify/bagitify.py"]
+ENTRYPOINT ["micromamba", "run", "python", "-m", "bagitify.cli"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM mambaorg/micromamba:1.5.1
+
 COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/project/environment.yml
-COPY --chown=$MAMBA_USER:$MAMBA_USER pyproject.toml /tmp/project/pyproject.toml
-COPY --chown=$MAMBA_USER:$MAMBA_USER bagitify /tmp/project/bagitify
 
 RUN micromamba install -y -n base -f /tmp/project/environment.yml && \
     micromamba clean --all --yes
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER pyproject.toml /tmp/project/pyproject.toml
+COPY --chown=$MAMBA_USER:$MAMBA_USER bagitify /tmp/project/bagitify
 
 WORKDIR /srv/bagitify
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ two phone numbers being saved in the bagit metadata.
 To actually call the program, run
 
 ```bash
-./bagitify/bagitify.py [-d DIRECTORY] [-s START] [-e END] [-v] [-f] <tabledap_url>`
+bagitify [-d DIRECTORY] [-s START] [-e END] [-v] [-f] <tabledap_url>`
 ```
 
 `-d` allows the user to specify the directory to create the bagit archive in. If not set,
@@ -50,7 +50,7 @@ Finally, `tabledap_url` is an ERDDAP tabledap url such as `https://erddap.secoor
 Putting it all together, bagitify might be run like so:
 
 ```bash
-python bagitify/bagitify.py -s 2022-05-01 -e 2022-08-01 https://erddap.secoora.org/erddap/tabledap/edu_usf_marine_comps_1407d550.html
+bagitify -s 2022-05-01 -e 2022-08-01 https://erddap.secoora.org/erddap/tabledap/edu_usf_marine_comps_1407d550.html
 ```
 
 By default, monthly netCDF files which have already been downloaded are skipped/not redownloaded, __unless__ the
@@ -91,7 +91,24 @@ BAGITIFY_USER=$(id -u) docker compose run bagitify
 
 Environment variables can also be managed using `--env-file` in `docker run`.
 
-### Contributing
+## Installation
+
+1. Install dependencties into a new conda environment:
+    ```
+    conda env create -f environment.yml
+    ```
+2. Then activate the environment:
+    ```
+    conda activate bagitify
+    ```
+3. And install the executable if you wish:
+    ```
+    pip install .
+    ```
+    - alternatively, to run the program you can just execute the module `python -m bagitify.cli`
+    - if you install with `pip` you should be able to run `bagitify`
+
+## Contributing
 
 Contributions via pull request are welcome. Please add tests for any new features and fix any
 formatting issues identified by `flake8` prior to submitting.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ Environment variables can also be managed using `--env-file` in `docker run`.
     - alternatively, to run the program you can just execute the module `python -m bagitify.cli`
     - if you install with `pip` you should be able to run `bagitify`
 
+## Testing
+
+With the project installed and environment active, run
+```
+python -m pytest
+```
+
+This will collect and run all tests in the `test/` dir like `pytest` does.
+
 ## Contributing
 
 Contributions via pull request are welcome. Please add tests for any new features and fix any

--- a/bagitify/bagit_wrapper.py
+++ b/bagitify/bagit_wrapper.py
@@ -1,0 +1,10 @@
+"""Module for managing BagIt archives."""
+
+from pathlib import Path
+
+
+def is_bag(bag_directory: Path) -> bool:
+    """Check if directory is a BagIt archive."""
+    return (bag_directory / "bagit.txt").is_file()
+
+# TODO move more stuff here

--- a/bagitify/bagit_wrapper.py
+++ b/bagitify/bagit_wrapper.py
@@ -1,5 +1,7 @@
 """Module for managing BagIt archives."""
 
+import bagit
+
 from pathlib import Path
 
 
@@ -7,4 +9,17 @@ def is_bag(bag_directory: Path) -> bool:
     """Check if directory is a BagIt archive."""
     return (bag_directory / "bagit.txt").is_file()
 
-# TODO move more stuff here
+
+def bag_it_up(bag_directory: Path, bagit_metadata: dict, create: bool = True):
+    """Create or update a BagIt archive."""
+    if create:
+        bagit.make_bag(bag_directory, bag_info=bagit_metadata, checksums=["sha256"])
+        return  # new bag created, done
+
+    # Open the existing bag
+    bag = bagit.Bag(str(bag_directory))
+    # Update bag-info
+    bag.info.update(bagit_metadata)
+    # Any potentially new files have already been written to the `data` payload directory,
+    # so just persist any metadata changes made and update manifests with checksums
+    bag.save(manifests=True)

--- a/bagitify/bagitify.py
+++ b/bagitify/bagitify.py
@@ -3,24 +3,26 @@
 For more information on the bagit standard, see: https://en.wikipedia.org/wiki/BagIt
 """
 
-import bagit
-import json
-import os
-import re
 import requests
-import tempfile
 
-from datetime import datetime as Datetime
 from pathlib import Path
 from typing import Optional
 
-from bagitify.bagit_wrapper import is_bag
-from bagitify.utils import are_same_fs, create_dir_if_not_exist
-
-DT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+from bagitify.bagit_wrapper import bag_it_up, is_bag
+from bagitify.download import download_data_for_bag
+from bagitify.metadata import prep_bagit_metadata
+from bagitify.utils import (
+    are_same_fs,
+    create_dir_if_not_exist,
+    Datetime,
+    format_datetime,
+    get_dataset_name_from_tabledap_url,
+    parse_datetime,
+)
 
 
 def get_start_end(tabledap_url: str) -> tuple[Datetime, Datetime]:
+    """Get the start and end times of the data in the tabledap dataset."""
     start_end_url = f'{tabledap_url}.csv0?time&orderByMinMax(%22time%22)'
     r = requests.get(start_end_url, allow_redirects=True)
     r.raise_for_status()
@@ -33,287 +35,6 @@ def get_start_end(tabledap_url: str) -> tuple[Datetime, Datetime]:
     return (start, end)
 
 
-def round_to_start_of_month(start_datetime: Datetime) -> Datetime:
-    month_start = Datetime(
-        day=1, month=start_datetime.month, year=start_datetime.year)
-    return month_start
-
-
-def round_to_next_month(end_datetime: Datetime) -> Datetime:
-    if end_datetime.month < 12:
-        next_month_start = Datetime(
-            day=1, month=end_datetime.month + 1, year=end_datetime.year)
-    else:
-        next_month_start = Datetime(
-            day=1, month=1, year=end_datetime.year + 1)
-    return next_month_start
-
-
-def format_datetime(datetime: Datetime) -> str:
-    return datetime.strftime(DT_FORMAT)
-
-
-def parse_datetime(dt_str: str) -> Datetime:
-    return Datetime.strptime(dt_str, DT_FORMAT)
-
-
-def should_download_netcdf(
-    existing_nc: Optional[Path],
-    force: bool,
-    end_datetime: Datetime,
-    verbose: bool
-) -> bool:
-    """Decide whether to download a netCDF file or not.
-    
-    Also print messages if verbose is True.
-    """
-    if not existing_nc or not existing_nc.is_file():
-        # No existing file
-        return True
-
-    if force:
-        if verbose:
-            print(f"File '{existing_nc}' exists but downloads are forced. Will re-download and overwrite.")
-        return True
-
-    nc_mtime = Datetime.fromtimestamp(existing_nc.stat().st_mtime)
-    if nc_mtime < end_datetime:
-        # The file was written before the end date time for this monthly chunk's range,
-        # therefore cannot contain the whole month of up to date data - unless somebody predicted the future :)
-        if verbose:
-            print(f"File '{existing_nc}' exists but was written before chunk ending {end_datetime}, re-downloading.")
-        return True
-
-    # File already exists and is up to date
-    return False
-
-
-def download_month_netcdf(
-    tabledap_url: str,
-    start_datetime: Datetime,
-    destination_dir: Path,
-    existing_files_dir: Optional[Path] = None,
-    verbose: bool = False,
-    force: bool = False,
-):
-    """Download netCDF file for the month starting with the provided datetime."""
-    end_datetime = round_to_next_month(start_datetime)
-
-    month_nc_url = f"{tabledap_url}.ncCFMA?&time>={format_datetime(start_datetime)}&time<{format_datetime(end_datetime)}"
-    nc_filename = gen_nc_filename(tabledap_url, start_datetime)
-    # destination can be a tmp directory so it might be different than existing files
-    destination_nc_path = destination_dir / nc_filename
-    existing_nc_path = existing_files_dir and existing_files_dir / nc_filename
-
-    if not should_download_netcdf(existing_nc_path, force, end_datetime, verbose):
-        if verbose:
-            print(f"Skipping download. File '{existing_nc_path}' already exists.")
-        return
-
-    if verbose:
-        print(f"Downloading nc for {format_datetime(start_datetime)} - {format_datetime(end_datetime)} to '{destination_nc_path}'.")
-
-    r = requests.get(month_nc_url, allow_redirects=True)
-    # dataset may contain data gaps one month or greater between start and end times
-    if r.status_code == 404 and 'Your query produced no matching results' in str(r.content):
-        print(f'No data found for month {format_datetime(start_datetime)}.')
-        return
-    r.raise_for_status()
-
-    with open(destination_nc_path, "wb") as fp:
-        fp.write(r.content)
-
-
-def get_start_dates_for_date_range(start_datetime: Datetime, end_datetime: Datetime) -> list[Datetime]:
-    month_start_dates = []
-    current_start = round_to_start_of_month(start_datetime)
-    if end_datetime != round_to_start_of_month(end_datetime):
-        end_datetime = round_to_next_month(end_datetime)
-    current_end = round_to_next_month(current_start)
-
-    while current_end <= end_datetime:
-        month_start_dates.append(current_start)
-        current_start = current_end
-        current_end = round_to_next_month(current_end)
-    return month_start_dates
-
-
-def download_netcdf_range(
-    tabledap_url: str,
-    start_datetime: Datetime,
-    end_datetime: Datetime,
-    destination_dir: Path,
-    existing_files_dir: Optional[Path] = None,
-    verbose: bool = False,
-    force: bool = False,
-):
-    """Download netCDF files for each month in the provided time range."""
-    for month_start_datetime in get_start_dates_for_date_range(start_datetime, end_datetime):
-        download_month_netcdf(
-            tabledap_url,
-            month_start_datetime,
-            destination_dir,
-            existing_files_dir=existing_files_dir,
-            verbose=verbose,
-            force=force,
-        )
-
-
-def move_tmp_to_bag(
-    bag_directory: Path,
-    tmp_destination: Path,
-    verbose: bool = False,
-    force: bool = False,
-):
-    """Move necessary files from a tmp download directory to the bag directory."""
-    bag_data_dir = bag_directory / "data"
-    bag_exists = is_bag(bag_directory)
-
-    if bag_exists and not force:
-        any_files_moved = False
-        # only kinda atomic - move individual netcdfs to the bag with existing netcdfs
-        for nc_file in tmp_destination.iterdir():
-            any_files_moved = True
-            os.rename(nc_file, bag_data_dir / nc_file.name)
-        if verbose and any_files_moved:
-            print(f"Moved files from '{tmp_destination}' to '{bag_data_dir}'")
-        return
-
-    if bag_exists:
-        # delete existing contents of `bag/data` so that tmp dir can overwrite it
-        for existing_nc_file in bag_data_dir.iterdir():
-            os.remove(existing_nc_file)
-        if verbose:
-            print(f"Cleared existing files in '{bag_data_dir}'")
-    # move/rename tmp dir to the destination dir (either `bag` or `bag/data`)
-    os.rename(tmp_destination, bag_data_dir if bag_exists else bag_directory)
-    if verbose:
-        print(f"Moved '{tmp_destination}' to '{bag_data_dir}'")
-
-
-def download_data_for_bag(
-    tabledap_url: str,
-    start_datetime: Datetime,
-    end_datetime: Datetime,
-    bag_directory: Path,
-    tmp_parent: Path,
-    verbose: bool = False,
-    force: bool = False,
-):
-    """Atomically-ish* download netCDF files for each month in the provided time range.
-
-    *Download netCDF files to a temporary directory, then move it to the bag directory.
-    If updating an existing bag without the force flag, files will be moved one by one.
-    """
-    with tempfile.TemporaryDirectory(prefix="bagitify-data-", dir=tmp_parent) as tmpdir:
-        # 1. Download necessary files to a tmp dir
-        tmp_destination = Path(tmpdir)
-        download_netcdf_range(
-            tabledap_url,
-            start_datetime,
-            end_datetime,
-            destination_dir=tmp_destination,
-            existing_files_dir=bag_directory / "data" if is_bag(bag_directory) else None,
-            verbose=verbose,
-            force=force,
-        )
-        # 2. move stuff from the tmp dir
-        move_tmp_to_bag(bag_directory, tmp_destination, verbose=verbose, force=force)
-
-
-def gen_nc_filename(tabledap_url: str, start_datetime: Datetime) -> str:
-    name_parts = [get_dataset_name_from_tabledap_url(tabledap_url)]
-    name_parts.append(start_datetime.strftime("%Y-%m") + ".nc")
-    name = "_".join(name_parts)
-    return name
-
-
-def get_dataset_name_from_tabledap_url(tabledap_url: str) -> str:
-    return tabledap_url.split("/")[-1]
-
-
-def get_metadata(tabledap_url: str) -> dict:
-    metadata_url = tabledap_url.replace("/tabledap/", "/info/") + "/index.json"
-    r = requests.get(metadata_url, allow_redirects=True)
-    r.raise_for_status()
-    metadata = json.loads(r.content.decode("utf-8"))
-    return metadata
-
-
-def parse_tabledap_metadata(tabledap_metadata: dict) -> dict:
-    rows = tabledap_metadata["table"]["rows"]
-    nested = {}
-    for row in rows:
-        row_type = row[0]
-        var_name = row[1]
-        att_name = row[2]
-        data_type = row[3]
-        data_value = row[4]
-
-        if row_type not in nested:
-            nested[row_type] = {}
-
-        if var_name not in nested[row_type]:
-            nested[row_type][var_name] = {}
-
-        nested[row_type][var_name][att_name] = {
-            "data_type": data_type, "data_value": data_value}
-    return nested
-
-
-def prep_bagit_metadata(tabledap_url: str, config_metadata: dict) -> dict:
-    tabledap_metadata = parse_tabledap_metadata(get_metadata(tabledap_url))
-    bagit_metadata = config_metadata
-    bagit_metadata["External-Description"] = (
-      f'Sensor data from station {"".join(tabledap_url.split("/")[-1].split(".")[0:-1])}'
-    )
-    title = tabledap_metadata["attribute"]["NC_GLOBAL"]["title"]["data_value"]
-    bagit_metadata["External-Identifier"] = title
-
-    return bagit_metadata
-
-
-def bag_it_up(bag_directory: Path, bagit_metadata: dict, create: bool = True):
-    """Create or update a BagIt archive."""
-    if create:
-        bagit.make_bag(bag_directory, bag_info=bagit_metadata, checksums=["sha256"])
-        return  # new bag created, done
-
-    # Open the existing bag
-    bag = bagit.Bag(str(bag_directory))
-    # Update bag-info
-    bag.info.update(bagit_metadata)
-    # Any potentially new files have already been written to the `data` payload directory,
-    # so just persist any metadata changes made and update manifests with checksums
-    bag.save(manifests=True)
-
-
-def config_metadata_from_env() -> dict:
-    config_items = ["Bag-Group-Identifier", "Contact-Email", "Contact-Name",
-                    "Contact-Phone", "Organization-address", "Source-Organization"]
-
-    config_metadata = {}
-    env_keys = list(dict(os.environ).keys())
-
-    for item in config_items:
-        var_name = "BAGIT_" + item.upper().replace("-", "_")
-        r = re.compile(f'^{var_name}')
-
-        vars_from_env = list(filter(r.match, env_keys))
-        if len(vars_from_env) < 1:
-            print(f'Warning: {var_name} not set! Defaulting to empty string.')
-            from_env = ""
-            # If we want to exit instead, or perform more validation, change this.
-        elif len(vars_from_env) == 1:
-            from_env = os.environ.get(vars_from_env[0])
-        else:
-            from_env = [os.environ.get(v) for v in vars_from_env]
-
-        config_metadata[item] = from_env
-
-    return config_metadata
-
-
 def run(
     tabledap_url: str,
     bag_directory: Optional[Path] = None,
@@ -324,7 +45,7 @@ def run(
     force: bool = False,
 ):
     """Generate a bagit archive from an ERDDAP tabledap dataset.
-    
+
     Note: If `force` is `False` any existing files that are not in erddap will remain.
     """
     # use default bag directory based on dataset name if not provided
@@ -370,8 +91,7 @@ def run(
         force=force,
     )
 
-    config_metadata = config_metadata_from_env()
-    bagit_metadata = prep_bagit_metadata(tabledap_url, config_metadata)
+    bagit_metadata = prep_bagit_metadata(tabledap_url)
 
     # update or create the bagit archive
     bag_it_up(bag_directory, bagit_metadata, create=not is_bag(bag_directory))

--- a/bagitify/bagitify.py
+++ b/bagitify/bagitify.py
@@ -8,10 +8,14 @@ import json
 import os
 import re
 import requests
+import tempfile
 
 from datetime import datetime as Datetime
 from pathlib import Path
 from typing import Optional
+
+from bagitify.bagit_wrapper import is_bag
+from bagitify.utils import are_same_fs, create_dir_if_not_exist
 
 DT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
@@ -53,33 +57,61 @@ def parse_datetime(dt_str: str) -> Datetime:
     return Datetime.strptime(dt_str, DT_FORMAT)
 
 
-def download_month_netcdf(tabledap_url: str, start_datetime: Datetime, destination_dir: Path, verbose: bool = False, force: bool = False):
+def should_download_netcdf(
+    existing_nc: Optional[Path],
+    force: bool,
+    end_datetime: Datetime,
+    verbose: bool
+) -> bool:
+    """Decide whether to download a netCDF file or not.
+    
+    Also print messages if verbose is True.
+    """
+    if not existing_nc or not existing_nc.is_file():
+        # No existing file
+        return True
+
+    if force:
+        if verbose:
+            print(f"File '{existing_nc}' exists but downloads are forced. Will re-download and overwrite.")
+        return True
+
+    nc_mtime = Datetime.fromtimestamp(existing_nc.stat().st_mtime)
+    if nc_mtime < end_datetime:
+        # The file was written before the end date time for this monthly chunk's range,
+        # therefore cannot contain the whole month of up to date data - unless somebody predicted the future :)
+        if verbose:
+            print(f"File '{existing_nc}' exists but was written before chunk ending {end_datetime}, re-downloading.")
+        return True
+
+    # File already exists and is up to date
+    return False
+
+
+def download_month_netcdf(
+    tabledap_url: str,
+    start_datetime: Datetime,
+    destination_dir: Path,
+    existing_files_dir: Optional[Path] = None,
+    verbose: bool = False,
+    force: bool = False,
+):
     """Download netCDF file for the month starting with the provided datetime."""
     end_datetime = round_to_next_month(start_datetime)
 
     month_nc_url = f"{tabledap_url}.ncCFMA?&time>={format_datetime(start_datetime)}&time<{format_datetime(end_datetime)}"
     nc_filename = gen_nc_filename(tabledap_url, start_datetime)
-    nc_path = destination_dir / nc_filename
+    # destination can be a tmp directory so it might be different than existing files
+    destination_nc_path = destination_dir / nc_filename
+    existing_nc_path = existing_files_dir and existing_files_dir / nc_filename
 
-    if nc_path.is_file():
-        if force:
-            if verbose:
-                print(f"File '{nc_path}' exists but downloads are forced. Deleting existing file and re-downloading.")
-            nc_path.unlink()
-        else:
-            nc_path_mtime = Datetime.fromtimestamp(nc_path.stat().st_mtime)
-            if nc_path_mtime < end_datetime:
-                # The file was written before the end date time for this monthly chunk's range,
-                # therefore cannot contain the whole month of up to date data - unless somebody predicted the future :)
-                if verbose:
-                    print(f"File '{nc_path}' exists but was written before chunk ending {end_datetime}, re-downloading.")
-            else:
-                if verbose:
-                    print(f"Skipping download. File '{nc_path}' already exists.")
-                return
+    if not should_download_netcdf(existing_nc_path, force, end_datetime, verbose):
+        if verbose:
+            print(f"Skipping download. File '{existing_nc_path}' already exists.")
+        return
 
-    elif verbose:
-        print(f"Downloading nc for {format_datetime(start_datetime)} - {format_datetime(end_datetime)} to '{nc_path}'.")
+    if verbose:
+        print(f"Downloading nc for {format_datetime(start_datetime)} - {format_datetime(end_datetime)} to '{destination_nc_path}'.")
 
     r = requests.get(month_nc_url, allow_redirects=True)
     # dataset may contain data gaps one month or greater between start and end times
@@ -88,7 +120,7 @@ def download_month_netcdf(tabledap_url: str, start_datetime: Datetime, destinati
         return
     r.raise_for_status()
 
-    with open(nc_path, "wb") as fp:
+    with open(destination_nc_path, "wb") as fp:
         fp.write(r.content)
 
 
@@ -111,12 +143,82 @@ def download_netcdf_range(
     start_datetime: Datetime,
     end_datetime: Datetime,
     destination_dir: Path,
+    existing_files_dir: Optional[Path] = None,
     verbose: bool = False,
     force: bool = False,
 ):
     """Download netCDF files for each month in the provided time range."""
     for month_start_datetime in get_start_dates_for_date_range(start_datetime, end_datetime):
-        download_month_netcdf(tabledap_url, month_start_datetime, destination_dir, verbose=verbose, force=force)
+        download_month_netcdf(
+            tabledap_url,
+            month_start_datetime,
+            destination_dir,
+            existing_files_dir=existing_files_dir,
+            verbose=verbose,
+            force=force,
+        )
+
+
+def move_tmp_to_bag(
+    bag_directory: Path,
+    tmp_destination: Path,
+    verbose: bool = False,
+    force: bool = False,
+):
+    """Move necessary files from a tmp download directory to the bag directory."""
+    bag_data_dir = bag_directory / "data"
+    bag_exists = is_bag(bag_directory)
+
+    if bag_exists and not force:
+        any_files_moved = False
+        # only kinda atomic - move individual netcdfs to the bag with existing netcdfs
+        for nc_file in tmp_destination.iterdir():
+            any_files_moved = True
+            os.rename(nc_file, bag_data_dir / nc_file.name)
+        if verbose and any_files_moved:
+            print(f"Moved files from '{tmp_destination}' to '{bag_data_dir}'")
+        return
+
+    if bag_exists:
+        # delete existing contents of `bag/data` so that tmp dir can overwrite it
+        for existing_nc_file in bag_data_dir.iterdir():
+            os.remove(existing_nc_file)
+        if verbose:
+            print(f"Cleared existing files in '{bag_data_dir}'")
+    # move/rename tmp dir to the destination dir (either `bag` or `bag/data`)
+    os.rename(tmp_destination, bag_data_dir if bag_exists else bag_directory)
+    if verbose:
+        print(f"Moved '{tmp_destination}' to '{bag_data_dir}'")
+
+
+def download_data_for_bag(
+    tabledap_url: str,
+    start_datetime: Datetime,
+    end_datetime: Datetime,
+    bag_directory: Path,
+    tmp_parent: Path,
+    verbose: bool = False,
+    force: bool = False,
+):
+    """Atomically-ish* download netCDF files for each month in the provided time range.
+
+    *Download netCDF files to a temporary directory, then move it to the bag directory.
+    If updating an existing bag without the force flag, files will be moved one by one.
+    """
+    with tempfile.TemporaryDirectory(prefix="bagitify-data-", dir=tmp_parent) as tmpdir:
+        # 1. Download necessary files to a tmp dir
+        tmp_destination = Path(tmpdir)
+        download_netcdf_range(
+            tabledap_url,
+            start_datetime,
+            end_datetime,
+            destination_dir=tmp_destination,
+            existing_files_dir=bag_directory / "data" if is_bag(bag_directory) else None,
+            verbose=verbose,
+            force=force,
+        )
+        # 2. move stuff from the tmp dir
+        move_tmp_to_bag(bag_directory, tmp_destination, verbose=verbose, force=force)
 
 
 def gen_nc_filename(tabledap_url: str, start_datetime: Datetime) -> str:
@@ -214,12 +316,33 @@ def config_metadata_from_env() -> dict:
 
 def run(
     tabledap_url: str,
-    bag_directory: Optional[Path],
+    bag_directory: Optional[Path] = None,
     requested_start_datetime: Optional[Datetime] = None,
     requested_end_datetime: Optional[Datetime] = None,
+    tmp_parent: Optional[Path] = None,
     verbose: bool = False,
     force: bool = False,
 ):
+    """Generate a bagit archive from an ERDDAP tabledap dataset.
+    
+    Note: If `force` is `False` any existing files that are not in erddap will remain.
+    """
+    # use default bag directory based on dataset name if not provided
+    if not bag_directory:
+        bag_directory = Path.cwd() / "bagit_archives" / get_dataset_name_from_tabledap_url(tabledap_url)
+    if not tmp_parent:
+        tmp_parent = bag_directory.parent / ".tmp-bagitify"
+
+    # create dirs if they don't already exist
+    create_dir_if_not_exist(bag_directory)
+    create_dir_if_not_exist(tmp_parent)
+
+    # check filesystem is the same so that we can move data atomically
+    if tmp_parent and not are_same_fs(tmp_parent, bag_directory):
+        raise ValueError(
+            f"Temporary directory '{tmp_parent}' must be on the same filesystem as the bag directory '{bag_directory}'."
+        )
+
     # clean up tabledap url
     tabledap_url = tabledap_url.lower()
     # remove .html suffix if present
@@ -234,21 +357,21 @@ def run(
     bag_start_datetime = max((d for d in [requested_start_datetime, data_start_datetime] if d))
     bag_end_datetime = min((d for d in [requested_end_datetime, data_end_datetime] if d))
 
-    # use default bag directory based on dataset name if not provided
-    if not bag_directory:
-        bag_directory = Path.cwd() / "bagit_archives" / get_dataset_name_from_tabledap_url(tabledap_url)
-
     # make sure the bag directory exists
     bag_directory.mkdir(parents=True, exist_ok=True)
-    # check if bag already exists
-    bag_exists = bag_directory.joinpath("bagit.txt").is_file()
-    # set destination for netCDF file downloads
-    data_destination = bag_directory.joinpath("data") if bag_exists else bag_directory
 
-    download_netcdf_range(tabledap_url, bag_start_datetime, bag_end_datetime, data_destination, verbose, force)
+    download_data_for_bag(
+        tabledap_url,
+        bag_start_datetime,
+        bag_end_datetime,
+        bag_directory,
+        tmp_parent=tmp_parent,
+        verbose=verbose,
+        force=force,
+    )
 
     config_metadata = config_metadata_from_env()
     bagit_metadata = prep_bagit_metadata(tabledap_url, config_metadata)
 
     # update or create the bagit archive
-    bag_it_up(bag_directory, bagit_metadata, create=not bag_exists)
+    bag_it_up(bag_directory, bagit_metadata, create=not is_bag(bag_directory))

--- a/bagitify/cli.py
+++ b/bagitify/cli.py
@@ -18,7 +18,14 @@ CLICK_DATETIME_FORMATS = ['%Y-%m-%d', '%Y-%m-%dT%H:%M:%SZ']
 @click.option('-s', '--start-date', type=click.DateTime(CLICK_DATETIME_FORMATS), default=None, help='Data start date')
 @click.option('-e', '--end-date', type=click.DateTime(CLICK_DATETIME_FORMATS), default=None, help='Data end date')
 @click.option('-v', '--verbose/--no-verbose', default=False, help='Print more information about the process')
-@click.option('-f', '--force/--no-force', default=False, help='Delete and redownload existing files')
+@click.option('-f', '--force/--no-force', default=False, help='Clear existing files in the archive and redownload')
+@click.option(
+    '-t',
+    '--tmp-parent',
+    type=click.Path(writable=True, file_okay=False, path_type=Path),
+    default=None,
+    help='Temporary directory for downloading netCDF files (must be on the same file system as the bag directory)',
+)
 @click.argument('tabledap_url')
 def cli(
   bag_directory: Optional[Path],
@@ -26,10 +33,11 @@ def cli(
   end_date: Optional[Datetime],
   verbose: bool,
   force: bool,
+  tmp_parent: Optional[Path],
   tabledap_url: str,
 ):
     """Generate NCEI bagit archives from an ERDDAP tabledap dataset at TABLEDAP_URL."""
-    run(tabledap_url, bag_directory, start_date, end_date, verbose, force)
+    run(tabledap_url, bag_directory, start_date, end_date, tmp_parent, verbose, force)
 
 
 if __name__ == "__main__":

--- a/bagitify/cli.py
+++ b/bagitify/cli.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from typing import Optional
 import click
 
-from bagitify.bagitify import Datetime, run
+from bagitify.bagitify import run
+from bagitify.utils import Datetime
 
 CLICK_DATETIME_FORMATS = ['%Y-%m-%d', '%Y-%m-%dT%H:%M:%SZ']
 

--- a/bagitify/cli.py
+++ b/bagitify/cli.py
@@ -1,0 +1,36 @@
+"""Command line interface for bagitify."""
+from pathlib import Path
+from typing import Optional
+import click
+
+from bagitify.bagitify import Datetime, run
+
+CLICK_DATETIME_FORMATS = ['%Y-%m-%d', '%Y-%m-%dT%H:%M:%SZ']
+
+
+@click.command()
+@click.option(
+    '-d',
+    '--bag-directory',
+    type=click.Path(writable=True, file_okay=False, path_type=Path),
+    help='Directory to create the bagit archive in',
+)
+@click.option('-s', '--start-date', type=click.DateTime(CLICK_DATETIME_FORMATS), default=None, help='Data start date')
+@click.option('-e', '--end-date', type=click.DateTime(CLICK_DATETIME_FORMATS), default=None, help='Data end date')
+@click.option('-v', '--verbose/--no-verbose', default=False, help='Print more information about the process')
+@click.option('-f', '--force/--no-force', default=False, help='Delete and redownload existing files')
+@click.argument('tabledap_url')
+def cli(
+  bag_directory: Optional[Path],
+  start_date: Optional[Datetime],
+  end_date: Optional[Datetime],
+  verbose: bool,
+  force: bool,
+  tabledap_url: str,
+):
+    """Generate NCEI bagit archives from an ERDDAP tabledap dataset at TABLEDAP_URL."""
+    run(tabledap_url, bag_directory, start_date, end_date, verbose, force)
+
+
+if __name__ == "__main__":
+    cli()

--- a/bagitify/download.py
+++ b/bagitify/download.py
@@ -1,0 +1,187 @@
+"""Functions related to downloading data from ERDDAP."""
+
+import os
+from pathlib import Path
+import tempfile
+from typing import Optional
+
+import requests
+from bagitify.bagit_wrapper import is_bag
+from bagitify.utils import (
+    Datetime,
+    format_datetime,
+    get_dataset_name_from_tabledap_url,
+    round_to_next_month,
+    round_to_start_of_month,
+)
+
+
+def gen_nc_filename(tabledap_url: str, start_datetime: Datetime) -> str:
+    name_parts = [get_dataset_name_from_tabledap_url(tabledap_url)]
+    name_parts.append(start_datetime.strftime("%Y-%m") + ".nc")
+    name = "_".join(name_parts)
+    return name
+
+
+def should_download_netcdf(
+    existing_nc: Optional[Path],
+    force: bool,
+    end_datetime: Datetime,
+    verbose: bool
+) -> bool:
+    """Decide whether to download a netCDF file or not.
+
+    Also print messages if verbose is True.
+    """
+    if not existing_nc or not existing_nc.is_file():
+        # No existing file
+        return True
+
+    if force:
+        if verbose:
+            print(f"File '{existing_nc}' exists but downloads are forced. Will re-download and overwrite.")
+        return True
+
+    nc_mtime = Datetime.fromtimestamp(existing_nc.stat().st_mtime)
+    if nc_mtime < end_datetime:
+        # The file was written before the end date time for this monthly chunk's range,
+        # therefore cannot contain the whole month of up to date data - unless somebody predicted the future :)
+        if verbose:
+            print(f"File '{existing_nc}' exists but was written before chunk ending {end_datetime}, re-downloading.")
+        return True
+
+    # File already exists and is up to date
+    return False
+
+
+def download_month_netcdf(
+    tabledap_url: str,
+    start_datetime: Datetime,
+    destination_dir: Path,
+    existing_files_dir: Optional[Path] = None,
+    verbose: bool = False,
+    force: bool = False,
+):
+    """Download netCDF file for the month starting with the provided datetime."""
+    end_datetime = round_to_next_month(start_datetime)
+
+    month_nc_url = f"{tabledap_url}.ncCFMA?&time>={format_datetime(start_datetime)}&time<{format_datetime(end_datetime)}"
+    nc_filename = gen_nc_filename(tabledap_url, start_datetime)
+    # destination can be a tmp directory so it might be different than existing files
+    destination_nc_path = destination_dir / nc_filename
+    existing_nc_path = existing_files_dir and existing_files_dir / nc_filename
+
+    if not should_download_netcdf(existing_nc_path, force, end_datetime, verbose):
+        if verbose:
+            print(f"Skipping download. File '{existing_nc_path}' already exists.")
+        return
+
+    if verbose:
+        print(f"Downloading nc for {format_datetime(start_datetime)} - {format_datetime(end_datetime)} to '{destination_nc_path}'.")
+
+    r = requests.get(month_nc_url, allow_redirects=True)
+    # dataset may contain data gaps one month or greater between start and end times
+    if r.status_code == 404 and 'Your query produced no matching results' in str(r.content):
+        print(f'No data found for month {format_datetime(start_datetime)}.')
+        return
+    r.raise_for_status()
+
+    with open(destination_nc_path, "wb") as fp:
+        fp.write(r.content)
+
+
+def get_start_dates_for_date_range(start_datetime: Datetime, end_datetime: Datetime) -> list[Datetime]:
+    month_start_dates = []
+    current_start = round_to_start_of_month(start_datetime)
+    if end_datetime != round_to_start_of_month(end_datetime):
+        end_datetime = round_to_next_month(end_datetime)
+    current_end = round_to_next_month(current_start)
+
+    while current_end <= end_datetime:
+        month_start_dates.append(current_start)
+        current_start = current_end
+        current_end = round_to_next_month(current_end)
+    return month_start_dates
+
+
+def download_netcdf_range(
+    tabledap_url: str,
+    start_datetime: Datetime,
+    end_datetime: Datetime,
+    destination_dir: Path,
+    existing_files_dir: Optional[Path] = None,
+    verbose: bool = False,
+    force: bool = False,
+):
+    """Download netCDF files for each month in the provided time range."""
+    for month_start_datetime in get_start_dates_for_date_range(start_datetime, end_datetime):
+        download_month_netcdf(
+            tabledap_url,
+            month_start_datetime,
+            destination_dir,
+            existing_files_dir=existing_files_dir,
+            verbose=verbose,
+            force=force,
+        )
+
+
+def move_tmp_to_bag(
+    bag_directory: Path,
+    tmp_destination: Path,
+    verbose: bool = False,
+    force: bool = False,
+):
+    """Move necessary files from a tmp download directory to the bag directory."""
+    bag_data_dir = bag_directory / "data"
+    bag_exists = is_bag(bag_directory)
+
+    if bag_exists and not force:
+        any_files_moved = False
+        # only kinda atomic - move individual netcdfs to the bag with existing netcdfs
+        for nc_file in tmp_destination.iterdir():
+            any_files_moved = True
+            os.rename(nc_file, bag_data_dir / nc_file.name)
+        if verbose and any_files_moved:
+            print(f"Moved files from '{tmp_destination}' to '{bag_data_dir}'")
+        return
+
+    if bag_exists:
+        # delete existing contents of `bag/data` so that tmp dir can overwrite it
+        for existing_nc_file in bag_data_dir.iterdir():
+            os.remove(existing_nc_file)
+        if verbose:
+            print(f"Cleared existing files in '{bag_data_dir}'")
+    # move/rename tmp dir to the destination dir (either `bag` or `bag/data`)
+    os.rename(tmp_destination, bag_data_dir if bag_exists else bag_directory)
+    if verbose:
+        print(f"Moved '{tmp_destination}' to '{bag_data_dir}'")
+
+
+def download_data_for_bag(
+    tabledap_url: str,
+    start_datetime: Datetime,
+    end_datetime: Datetime,
+    bag_directory: Path,
+    tmp_parent: Path,
+    verbose: bool = False,
+    force: bool = False,
+):
+    """Atomically-ish* download netCDF files for each month in the provided time range.
+
+    *Download netCDF files to a temporary directory, then move it to the bag directory.
+    If updating an existing bag without the force flag, files will be moved one by one.
+    """
+    with tempfile.TemporaryDirectory(prefix="bagitify-data-", dir=tmp_parent) as tmpdir:
+        # 1. Download necessary files to a tmp dir
+        tmp_destination = Path(tmpdir)
+        download_netcdf_range(
+            tabledap_url,
+            start_datetime,
+            end_datetime,
+            destination_dir=tmp_destination,
+            existing_files_dir=bag_directory / "data" if is_bag(bag_directory) else None,
+            verbose=verbose,
+            force=force,
+        )
+        # 2. move stuff from the tmp dir
+        move_tmp_to_bag(bag_directory, tmp_destination, verbose=verbose, force=force)

--- a/bagitify/download.py
+++ b/bagitify/download.py
@@ -171,7 +171,11 @@ def download_data_for_bag(
     *Download netCDF files to a temporary directory, then move it to the bag directory.
     If updating an existing bag without the force flag, files will be moved one by one.
     """
-    with tempfile.TemporaryDirectory(prefix="bagitify-data-", dir=tmp_parent) as tmpdir:
+    dataset_name = get_dataset_name_from_tabledap_url(tabledap_url)
+    with tempfile.TemporaryDirectory(prefix=f"{dataset_name}-", dir=tmp_parent) as tmpdir:
+        if verbose:
+            print(f"Using bag directory '{bag_directory}'")
+            print(f"Using temp directory '{tmpdir}'")
         # 1. Download necessary files to a tmp dir
         tmp_destination = Path(tmpdir)
         download_netcdf_range(

--- a/bagitify/metadata.py
+++ b/bagitify/metadata.py
@@ -1,0 +1,74 @@
+"""Functions to prepare metadata for the BagIt archive."""
+
+import json
+import os
+import re
+import requests
+
+
+def config_metadata_from_env() -> dict:
+    """Get metadata from environment variables."""
+    config_items = ["Bag-Group-Identifier", "Contact-Email", "Contact-Name",
+                    "Contact-Phone", "Organization-address", "Source-Organization"]
+
+    config_metadata = {}
+    env_keys = list(dict(os.environ).keys())
+
+    for item in config_items:
+        var_name = "BAGIT_" + item.upper().replace("-", "_")
+        r = re.compile(f'^{var_name}')
+
+        vars_from_env = list(filter(r.match, env_keys))
+        if len(vars_from_env) < 1:
+            print(f'Warning: {var_name} not set! Defaulting to empty string.')
+            from_env = ""
+            # If we want to exit instead, or perform more validation, change this.
+        elif len(vars_from_env) == 1:
+            from_env = os.environ.get(vars_from_env[0])
+        else:
+            from_env = [os.environ.get(v) for v in vars_from_env]
+
+        config_metadata[item] = from_env
+
+    return config_metadata
+
+
+def get_metadata(tabledap_url: str) -> dict:
+    metadata_url = tabledap_url.replace("/tabledap/", "/info/") + "/index.json"
+    r = requests.get(metadata_url, allow_redirects=True)
+    r.raise_for_status()
+    metadata = json.loads(r.content.decode("utf-8"))
+    return metadata
+
+
+def parse_tabledap_metadata(tabledap_metadata: dict) -> dict:
+    rows = tabledap_metadata["table"]["rows"]
+    nested = {}
+    for row in rows:
+        row_type = row[0]
+        var_name = row[1]
+        att_name = row[2]
+        data_type = row[3]
+        data_value = row[4]
+
+        if row_type not in nested:
+            nested[row_type] = {}
+
+        if var_name not in nested[row_type]:
+            nested[row_type][var_name] = {}
+
+        nested[row_type][var_name][att_name] = {
+            "data_type": data_type, "data_value": data_value}
+    return nested
+
+
+def prep_bagit_metadata(tabledap_url: str) -> dict:
+    tabledap_metadata = parse_tabledap_metadata(get_metadata(tabledap_url))
+    bagit_metadata = config_metadata_from_env()
+    bagit_metadata["External-Description"] = (
+      f'Sensor data from station {"".join(tabledap_url.split("/")[-1].split(".")[0:-1])}'
+    )
+    title = tabledap_metadata["attribute"]["NC_GLOBAL"]["title"]["data_value"]
+    bagit_metadata["External-Identifier"] = title
+
+    return bagit_metadata

--- a/bagitify/utils.py
+++ b/bagitify/utils.py
@@ -2,11 +2,15 @@
 import os
 
 from pathlib import Path
+from datetime import datetime as Datetime
+
+
+DT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
 def are_same_fs(path1: Path, path2: Path) -> bool:
     """Check if two paths are on the same filesystem.
-    
+
     Assuming that the paths exist, otherwise will raise error.
     """
     return os.stat(path1).st_dev == os.stat(path2).st_dev
@@ -14,3 +18,31 @@ def are_same_fs(path1: Path, path2: Path) -> bool:
 
 def create_dir_if_not_exist(dir: Path):
     os.makedirs(dir, exist_ok=True)
+
+
+def format_datetime(datetime: Datetime) -> str:
+    return datetime.strftime(DT_FORMAT)
+
+
+def parse_datetime(dt_str: str) -> Datetime:
+    return Datetime.strptime(dt_str, DT_FORMAT)
+
+
+def get_dataset_name_from_tabledap_url(tabledap_url: str) -> str:
+    return tabledap_url.split("/")[-1]
+
+
+def round_to_start_of_month(start_datetime: Datetime) -> Datetime:
+    month_start = Datetime(
+        day=1, month=start_datetime.month, year=start_datetime.year)
+    return month_start
+
+
+def round_to_next_month(end_datetime: Datetime) -> Datetime:
+    if end_datetime.month < 12:
+        next_month_start = Datetime(
+            day=1, month=end_datetime.month + 1, year=end_datetime.year)
+    else:
+        next_month_start = Datetime(
+            day=1, month=1, year=end_datetime.year + 1)
+    return next_month_start

--- a/bagitify/utils.py
+++ b/bagitify/utils.py
@@ -1,0 +1,16 @@
+"""Helpers too generic to be in other modules."""
+import os
+
+from pathlib import Path
+
+
+def are_same_fs(path1: Path, path2: Path) -> bool:
+    """Check if two paths are on the same filesystem.
+    
+    Assuming that the paths exist, otherwise will raise error.
+    """
+    return os.stat(path1).st_dev == os.stat(path2).st_dev
+
+
+def create_dir_if_not_exist(dir: Path):
+    os.makedirs(dir, exist_ok=True)

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,3 @@ dependencies:
  - pytest=7.4.2
  - requests=2.31.0
  - python=3.12
- - pip
- - pip:
-   - -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,6 @@ exclude = ["bagit_archives"]
 [build-system]
 requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
+
+[project.scripts]
+bagitify = "bagitify.cli:cli"

--- a/test/test_bagitify.py
+++ b/test/test_bagitify.py
@@ -4,7 +4,8 @@ import json
 import os
 import shutil
 
-from bagitify import bagitify
+from bagitify.bagit_wrapper import bag_it_up
+from bagitify.download import get_start_dates_for_date_range
 
 test_data_dir = os.path.join(os.path.dirname(__file__), "test-data")
 testing_netcdf = os.path.join(test_data_dir, "netcdf")
@@ -12,7 +13,7 @@ testing_metadata = os.path.join(test_data_dir, "metadata.json")
 
 
 def test_get_start_dates_for_date_range():
-    assert bagitify.get_start_dates_for_date_range(
+    assert get_start_dates_for_date_range(
         start_datetime=datetime(2023, 3, 22),
         end_datetime=datetime(2023, 6, 19),
     ) == [
@@ -22,7 +23,7 @@ def test_get_start_dates_for_date_range():
         datetime(2023, 6, 1),
     ]
 
-    assert bagitify.get_start_dates_for_date_range(
+    assert get_start_dates_for_date_range(
         start_datetime=datetime(2023, 11, 1),
         end_datetime=datetime(2024, 4, 1),
     ) == [
@@ -33,7 +34,7 @@ def test_get_start_dates_for_date_range():
         datetime(2024, 3, 1),
     ]
 
-    assert bagitify.get_start_dates_for_date_range(
+    assert get_start_dates_for_date_range(
         start_datetime=datetime(2023, 11, 1),
         end_datetime=datetime(2024, 4, 2),
     ) == [
@@ -53,7 +54,7 @@ def test_archive_creation(tmp_path):
     with open(testing_metadata, "r") as fp:
         bagit_metadata = json.load(fp)
 
-    bagitify.bag_it_up(Path(tmp_bag_dir), bagit_metadata)
+    bag_it_up(Path(tmp_bag_dir), bagit_metadata)
 
     assert os.path.exists(os.path.join(tmp_bag_dir, "data", "edu_usf_marine_comps_2022-07.nc"))
 


### PR DESCRIPTION
https://axds.atlassian.net/browse/AOOS-471

I plan on adding an option to do the "atomic" netcdf download but before I add more code I decided to refactor a bit - [first commit](https://github.com/axiom-data-science/bagitify/pull/4/commits/d4ee09c7d3929096b2132ad81f16319007daa90a) :
- switch to using modules instead of single script file
  - changes installation and execution process (update readme, Dockerfile, pyproject.toml)
- move the CLI definition to its own file
  - add help strings to options
- also simplify how `datetime.datetime` is imported and referenced
- update few type hints (adding `Optional` to the `cli` args to make it more accurate)
- make constants all upper case

[52c8c43](https://github.com/axiom-data-science/bagitify/pull/4/commits/52c8c433a1b6707653e083064ad27c7c2b83977a) contains the new feature - more atomic downloads
- it ended up being a little tricky since there are two factors to consider: updating existing bag vs new bag and force flag

Here's an example run with existing bag and force flag on:
```
$ python -m bagitify.cli -s 2022-05-01 -e 2022-08-01 -d ./aoos/test -v https://erddap.secoora.org/erddap/tabledap/edu_usf_marine_comps_1407d550.html -
f
Dataset has time range 2017-05-03T06:00:00Z - 2022-09-29T18:54:00Z
File 'aoos/test/data/edu_usf_marine_comps_1407d550_2022-05.nc' exists but downloads are forced. Will re-download and overwrite.
Downloading nc for 2022-05-01T00:00:00Z - 2022-06-01T00:00:00Z to '/mnt/archive-v2/aoos/bagitify-data-xsbphb5j/edu_usf_marine_comps_1407d550_2022-05.nc'.
File 'aoos/test/data/edu_usf_marine_comps_1407d550_2022-06.nc' exists but downloads are forced. Will re-download and overwrite.
Downloading nc for 2022-06-01T00:00:00Z - 2022-07-01T00:00:00Z to '/mnt/archive-v2/aoos/bagitify-data-xsbphb5j/edu_usf_marine_comps_1407d550_2022-06.nc'.
File 'aoos/test/data/edu_usf_marine_comps_1407d550_2022-07.nc' exists but downloads are forced. Will re-download and overwrite.
Downloading nc for 2022-07-01T00:00:00Z - 2022-08-01T00:00:00Z to '/mnt/archive-v2/aoos/bagitify-data-xsbphb5j/edu_usf_marine_comps_1407d550_2022-07.nc'.
Cleared existing files in 'aoos/test/data'
Moved '/mnt/archive-v2/aoos/bagitify-data-xsbphb5j' to 'aoos/test/data'
```

Here's an example with existing bag in need of update without force:
```
$ python -m bagitify.cli -s 2022-05-01 -e 2022-08-01 -d ./aoos/test -v https://erddap.secoora.org/erddap/tabledap/edu_usf_marine_comps_1407d550.html 
Dataset has time range 2017-05-03T06:00:00Z - 2022-09-29T18:54:00Z
Skipping download. File 'aoos/test/data/edu_usf_marine_comps_1407d550_2022-05.nc' already exists.
Skipping download. File 'aoos/test/data/edu_usf_marine_comps_1407d550_2022-06.nc' already exists.
Downloading nc for 2022-07-01T00:00:00Z - 2022-08-01T00:00:00Z to '/mnt/archive-v2/aoos/bagitify-data-cuui0bge/edu_usf_marine_comps_1407d550_2022-07.nc'.
```

last commit contains a few more refactoring - this time only moving whole functions between files and adding few docstrings - no actual code change (except [this](https://github.com/axiom-data-science/bagitify/pull/4/commits/a45e0ae78748575ee84b94c90f48639b903ae80d#r1964565897))