### PR TITLE
Organize datasets in naming_authority subdirectories, add root_directory arg

### DIFF
--- a/bagitify/bagitify.py
+++ b/bagitify/bagitify.py
@@ -10,13 +10,15 @@ from typing import Callable, Optional
 
 from bagitify.bagit_wrapper import bag_it_up, is_bag
 from bagitify.download import download_data_for_bag
-from bagitify.metadata import prep_bagit_metadata
+from bagitify.metadata import (
+    get_dataset_name,
+    prep_bagit_metadata,
+)
 from bagitify.utils import (
     are_same_fs,
     create_dir_if_not_exist,
     Datetime,
     format_datetime,
-    get_dataset_name_from_tabledap_url,
     parse_datetime,
 )
 
@@ -38,6 +40,7 @@ def get_start_end(tabledap_url: str) -> tuple[Datetime, Datetime]:
 def run(
     tabledap_url: str,
     bag_directory: Optional[Path] = None,
+    root_directory: Optional[Path] = None,
     requested_start_datetime: Optional[Datetime] = None,
     requested_end_datetime: Optional[Datetime] = None,
     tmp_parent: Optional[Path] = None,
@@ -51,9 +54,23 @@ def run(
     after data is downloaded from ERDDAP and before it gets bagged.
     Note: If `force` is `False` any existing files that are not in erddap will remain.
     """
-    # use default bag directory based on dataset name if not provided
+
+    if bag_directory and root_directory:
+        print('Both bag_directory and root_directory are set, ignoring root_directory')
+
+    # clean up tabledap url
+    tabledap_url = tabledap_url.lower()
+    # remove .html suffix if present
+    if tabledap_url.endswith(".html"):
+        tabledap_url = tabledap_url.removesuffix(".html")
+
+    dataset_name = get_dataset_name(tabledap_url)
+
+    # use default bag directory based on naming_authority and dataset id if not provided
     if not bag_directory:
-        bag_directory = Path.cwd() / "bagit_archives" / get_dataset_name_from_tabledap_url(tabledap_url)
+        if not root_directory:
+            root_directory = Path.cwd() / "bagit_archives"
+        bag_directory = root_directory / dataset_name
     if not tmp_parent:
         tmp_parent = bag_directory.parent / ".tmp-bagitify"
 
@@ -66,12 +83,6 @@ def run(
         raise ValueError(
             f"Temporary directory '{tmp_parent}' must be on the same filesystem as the bag directory '{bag_directory}'."
         )
-
-    # clean up tabledap url
-    tabledap_url = tabledap_url.lower()
-    # remove .html suffix if present
-    if tabledap_url.endswith(".html"):
-        tabledap_url = tabledap_url.removesuffix(".html")
 
     # determine actual range of data available in the target tabledap dataset
     data_start_datetime, data_end_datetime = get_start_end(tabledap_url)

--- a/bagitify/cli.py
+++ b/bagitify/cli.py
@@ -16,6 +16,12 @@ CLICK_DATETIME_FORMATS = ['%Y-%m-%d', '%Y-%m-%dT%H:%M:%SZ']
     type=click.Path(writable=True, file_okay=False, path_type=Path),
     help='Directory to create the bagit archive in',
 )
+@click.option(
+    '-r',
+    '--root-directory',
+    type=click.Path(writable=True, file_okay=False, path_type=Path),
+    help='Root directory in which to create archive directories',
+)
 @click.option('-s', '--start-date', type=click.DateTime(CLICK_DATETIME_FORMATS), default=None, help='Data start date')
 @click.option('-e', '--end-date', type=click.DateTime(CLICK_DATETIME_FORMATS), default=None, help='Data end date')
 @click.option('-v', '--verbose/--no-verbose', default=False, help='Print more information about the process')
@@ -29,16 +35,17 @@ CLICK_DATETIME_FORMATS = ['%Y-%m-%d', '%Y-%m-%dT%H:%M:%SZ']
 )
 @click.argument('tabledap_url')
 def cli(
-  bag_directory: Optional[Path],
-  start_date: Optional[Datetime],
-  end_date: Optional[Datetime],
-  verbose: bool,
-  force: bool,
-  tmp_parent: Optional[Path],
-  tabledap_url: str,
+    bag_directory: Optional[Path],
+    root_directory: Optional[Path],
+    start_date: Optional[Datetime],
+    end_date: Optional[Datetime],
+    verbose: bool,
+    force: bool,
+    tmp_parent: Optional[Path],
+    tabledap_url: str,
 ):
     """Generate NCEI bagit archives from an ERDDAP tabledap dataset at TABLEDAP_URL."""
-    run(tabledap_url, bag_directory, start_date, end_date, tmp_parent, verbose, force)
+    run(tabledap_url, bag_directory, root_directory, start_date, end_date, tmp_parent, verbose, force)
 
 
 if __name__ == "__main__":

--- a/bagitify/download.py
+++ b/bagitify/download.py
@@ -7,17 +7,17 @@ from typing import Optional
 
 import requests
 from bagitify.bagit_wrapper import is_bag
+from bagitify.metadata import get_dataset_name
 from bagitify.utils import (
     Datetime,
     format_datetime,
-    get_dataset_name_from_tabledap_url,
     round_to_next_month,
     round_to_start_of_month,
 )
 
 
 def gen_nc_filename(tabledap_url: str, start_datetime: Datetime) -> str:
-    name_parts = [get_dataset_name_from_tabledap_url(tabledap_url)]
+    name_parts = [get_dataset_name(tabledap_url)]
     name_parts.append(start_datetime.strftime("%Y-%m") + ".nc")
     name = "_".join(name_parts)
     return name
@@ -174,7 +174,7 @@ def download_data_for_bag(
     *Download netCDF files to a temporary directory, then move it to the bag directory.
     If updating an existing bag without the force flag, files will be moved one by one.
     """
-    dataset_name = get_dataset_name_from_tabledap_url(tabledap_url)
+    dataset_name = get_dataset_name(tabledap_url)
     with tempfile.TemporaryDirectory(prefix=f"{dataset_name}-", dir=tmp_parent) as tmpdir:
         if verbose:
             print(f"Using bag directory '{bag_directory}'")

--- a/bagitify/metadata.py
+++ b/bagitify/metadata.py
@@ -5,6 +5,8 @@ import os
 import re
 import requests
 
+from functools import lru_cache
+
 
 def config_metadata_from_env() -> dict:
     """Get metadata from environment variables."""
@@ -33,15 +35,13 @@ def config_metadata_from_env() -> dict:
     return config_metadata
 
 
+@lru_cache(maxsize=100)
 def get_metadata(tabledap_url: str) -> dict:
     metadata_url = tabledap_url.replace("/tabledap/", "/info/") + "/index.json"
     r = requests.get(metadata_url, allow_redirects=True)
     r.raise_for_status()
-    metadata = json.loads(r.content.decode("utf-8"))
-    return metadata
+    tabledap_metadata = json.loads(r.content.decode("utf-8"))
 
-
-def parse_tabledap_metadata(tabledap_metadata: dict) -> dict:
     rows = tabledap_metadata["table"]["rows"]
     nested = {}
     for row in rows:
@@ -63,7 +63,7 @@ def parse_tabledap_metadata(tabledap_metadata: dict) -> dict:
 
 
 def prep_bagit_metadata(tabledap_url: str) -> dict:
-    tabledap_metadata = parse_tabledap_metadata(get_metadata(tabledap_url))
+    tabledap_metadata = get_metadata(tabledap_url)
     bagit_metadata = config_metadata_from_env()
     bagit_metadata["External-Description"] = (
       f'Sensor data from station {"".join(tabledap_url.split("/")[-1].split(".")[0:-1])}'
@@ -72,3 +72,29 @@ def prep_bagit_metadata(tabledap_url: str) -> dict:
     bagit_metadata["External-Identifier"] = title
 
     return bagit_metadata
+
+
+def get_naming_authority_and_id(tabledap_url: str) -> tuple[str, str]:
+    tabledap_metadata = get_metadata(tabledap_url)
+    try:
+        naming_authority = tabledap_metadata["attribute"]["NC_GLOBAL"]["naming_authority"]["data_value"]
+    except KeyError:
+        raise ValueError(f"naming_authority not found for {tabledap_url}")
+
+    try:
+        dataset_id = tabledap_metadata["attribute"]["NC_GLOBAL"]["id"]["data_value"]
+    except KeyError:
+        raise ValueError(f"id not found for {tabledap_url}")
+
+    path_regex = re.compile("[a-zA-ZáéíóúüñÁÉÍÓÚÜÑ0-9._-]+")
+
+    if not path_regex.fullmatch(naming_authority):
+        raise ValueError(f"naming_authority {naming_authority} contains disallowed characters")
+    if not path_regex.fullmatch(dataset_id):
+        raise ValueError(f"dataset id {dataset_id} contains disallowed characters")
+
+    return naming_authority, dataset_id
+
+
+def get_dataset_name(tabledap_url: str) -> str:
+    return '.'.join(get_naming_authority_and_id(tabledap_url))

--- a/bagitify/utils.py
+++ b/bagitify/utils.py
@@ -28,10 +28,6 @@ def parse_datetime(dt_str: str) -> Datetime:
     return Datetime.strptime(dt_str, DT_FORMAT)
 
 
-def get_dataset_name_from_tabledap_url(tabledap_url: str) -> str:
-    return tabledap_url.split("/")[-1]
-
-
 def round_to_start_of_month(start_datetime: Datetime) -> Datetime:
     month_start = Datetime(
         day=1, month=start_datetime.month, year=start_datetime.year)


### PR DESCRIPTION
* Add root-directory argument to alter default dataset root directory
* Organize datasets by naming_authority subdirectories
* Include naming_authority prefix in dataset names
* Cache metadata requests
* Validate naming_authority and id for filepath safe input